### PR TITLE
[Feature/#1] 메인탭의 거래 목록 카드 위젯 추가

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,13 @@ class _AppState extends State<App> {
                 SizedBox(
                   height: 60,
                 ),
-                ListCard(),
+                ListCard(
+                  tranState: '거래중',
+                  tranDate: '2023.08.02 16:52',
+                  tranPerson: '손후추',
+                  tranItem: '노트북',
+                  tranPrice: '100,000원',
+                ),
               ],
             ),
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:ojakgyo/widgets/list_card.dart';
 
 void main() {
   runApp(const App());
@@ -23,53 +24,11 @@ class _AppState extends State<App> {
               horizontal: 25,
             ),
             child: Column(
-              children: [
-                const SizedBox(
+              children: const [
+                SizedBox(
                   height: 60,
                 ),
-                Container(
-                  decoration: BoxDecoration(
-                    color: const Color(0xFF1F2123),
-                    borderRadius: BorderRadius.circular(20),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.all(30),
-                    child: Column(
-                      children: const [
-                        Text(
-                          '거래 상태',
-                          style: TextStyle(
-                            color: Colors.white,
-                          ),
-                        ),
-                        Text(
-                          '거래 날짜',
-                          style: TextStyle(
-                            color: Colors.white,
-                          ),
-                        ),
-                        Text(
-                          '거래자',
-                          style: TextStyle(
-                            color: Colors.white,
-                          ),
-                        ),
-                        Text(
-                          '거래 상품',
-                          style: TextStyle(
-                            color: Colors.white,
-                          ),
-                        ),
-                        Text(
-                          '거래 가격',
-                          style: TextStyle(
-                            color: Colors.white,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
+                ListCard(),
               ],
             ),
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,9 +23,52 @@ class _AppState extends State<App> {
               horizontal: 25,
             ),
             child: Column(
-              children: const [
-                SizedBox(
+              children: [
+                const SizedBox(
                   height: 60,
+                ),
+                Container(
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF1F2123),
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(30),
+                    child: Column(
+                      children: const [
+                        Text(
+                          '거래 상태',
+                          style: TextStyle(
+                            color: Colors.white,
+                          ),
+                        ),
+                        Text(
+                          '거래 날짜',
+                          style: TextStyle(
+                            color: Colors.white,
+                          ),
+                        ),
+                        Text(
+                          '거래자',
+                          style: TextStyle(
+                            color: Colors.white,
+                          ),
+                        ),
+                        Text(
+                          '거래 상품',
+                          style: TextStyle(
+                            color: Colors.white,
+                          ),
+                        ),
+                        Text(
+                          '거래 가격',
+                          style: TextStyle(
+                            color: Colors.white,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
                 ),
               ],
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:ojakgyo/widgets/list_card.dart';
 
 void main() {
   runApp(const App());
@@ -27,13 +26,6 @@ class _AppState extends State<App> {
               children: const [
                 SizedBox(
                   height: 60,
-                ),
-                ListCard(
-                  tranState: '거래중',
-                  tranDate: '2023.08.02 16:52',
-                  tranPerson: '손후추',
-                  tranItem: '노트북',
-                  tranPrice: '100,000원',
                 ),
               ],
             ),

--- a/lib/widgets/list_card.dart
+++ b/lib/widgets/list_card.dart
@@ -1,7 +1,20 @@
 import 'package:flutter/material.dart';
 
 class ListCard extends StatefulWidget {
-  const ListCard({super.key});
+  const ListCard({
+    Key? key,
+    required this.tranState, // 거래 상태
+    required this.tranDate, // 거래 날짜
+    required this.tranPerson, // 거래 대상
+    required this.tranItem, // 거래 품목
+    required this.tranPrice, // 거래 가격
+  }) : super(key: key);
+
+  final String tranState;
+  final String tranDate;
+  final String tranPerson;
+  final String tranItem;
+  final String tranPrice;
 
   @override
   State<ListCard> createState() => _AppState();
@@ -18,34 +31,34 @@ class _AppState extends State<ListCard> {
       child: Padding(
         padding: const EdgeInsets.all(30),
         child: Column(
-          children: const [
+          children: [
             Text(
-              '거래 상태',
-              style: TextStyle(
+              widget.tranState,
+              style: const TextStyle(
                 color: Colors.white,
               ),
             ),
             Text(
-              '거래 날짜',
-              style: TextStyle(
+              widget.tranDate,
+              style: const TextStyle(
                 color: Colors.white,
               ),
             ),
             Text(
-              '거래자',
-              style: TextStyle(
+              widget.tranPerson,
+              style: const TextStyle(
                 color: Colors.white,
               ),
             ),
             Text(
-              '거래 상품',
-              style: TextStyle(
+              widget.tranItem,
+              style: const TextStyle(
                 color: Colors.white,
               ),
             ),
             Text(
-              '거래 가격',
-              style: TextStyle(
+              widget.tranPrice,
+              style: const TextStyle(
                 color: Colors.white,
               ),
             ),

--- a/lib/widgets/list_card.dart
+++ b/lib/widgets/list_card.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+class ListCard extends StatefulWidget {
+  const ListCard({super.key});
+
+  @override
+  State<ListCard> createState() => _AppState();
+}
+
+class _AppState extends State<ListCard> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: const Color(0xFF1F2123),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(30),
+        child: Column(
+          children: const [
+            Text(
+              '거래 상태',
+              style: TextStyle(
+                color: Colors.white,
+              ),
+            ),
+            Text(
+              '거래 날짜',
+              style: TextStyle(
+                color: Colors.white,
+              ),
+            ),
+            Text(
+              '거래자',
+              style: TextStyle(
+                color: Colors.white,
+              ),
+            ),
+            Text(
+              '거래 상품',
+              style: TextStyle(
+                color: Colors.white,
+              ),
+            ),
+            Text(
+              '거래 가격',
+              style: TextStyle(
+                color: Colors.white,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:ojakgyo/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const App());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
**widgets/list_card.dart**
- 거래 목록을 보여줄 카드를 추가
- 카드는 거래 상태, 거래 날짜, 거래 대상, 거래 품목, 거래 가격 등을 파라미터로 받아 text로 보여줌

나중에 데이터를 받아와서 파라미터로 적용하고,
style을 줘야합니다🙃
(상태 표시도 함께 ..)