### PR TITLE
[Feature/#73] 거래대상자 조회시 거래 대상자의 거래 상태 수정

### DIFF
--- a/lib/widgets/counterparty_list.dart
+++ b/lib/widgets/counterparty_list.dart
@@ -32,6 +32,13 @@ class _AppState extends State<CounterPartyList> {
   bool isToggled = true;
   late String modifiedPhone = '';
 
+  Map<String, dynamic> dealState = {
+      'BEFORE': '거래 전',
+      'DEALING': '거래 중',
+      'COMPLETED': '거래 완료',
+      'CANCELED': '거래 취소',
+    };
+
   @override
   void initState() {
     super.initState();
@@ -180,7 +187,7 @@ class _AppState extends State<CounterPartyList> {
                                                 children: [
                                                   const Text("거래 상태 : "),
                                                   Text(
-                                                    items.dealStatus ??
+                                                    dealState[items.dealStatus] ??
                                                         'Unknown',
                                                     style: const TextStyle(
                                                         color:


### PR DESCRIPTION
**lib/widgets/counterparty_list.dart**
- 거래 등록의 거래 대상자 조회시 거래 대상자의 거래 상태가 "DEALING"에서 "거래 중"으로 표시되도록 수정

issues : #73