### PR TITLE
[Feature/#50] 거래 상세 보기 페이지 구현

### DIFF
--- a/lib/src/pages/tran_detail_page.dart
+++ b/lib/src/pages/tran_detail_page.dart
@@ -153,7 +153,6 @@ class _TranDetailPageState extends State<TranDetailPage> {
           },
         );
       } else {
-        print('실패다 이자식아');
         setState(
           () {
             isChecked = false;
@@ -490,7 +489,8 @@ class _TranDetailPageState extends State<TranDetailPage> {
                           RegisterBtn(
                             btnName: '거래파기',
                             onPressed: () {
-                              showDialog(
+                              if (tranDetail.dealStatus == "BEFORE") {
+                                showDialog(
                                 context: context,
                                 builder: (BuildContext context) {
                                   return CustomAlertDialog(
@@ -498,7 +498,14 @@ class _TranDetailPageState extends State<TranDetailPage> {
                                     content: const Text('거래를 파기하시겠습니까?'),
                                     actions: [
                                       RegisterBtn(
-                                        btnName: '확인',
+                                        btnName: '파기',
+                                        onPressed: () {
+                                          Navigator.pop(context);
+                                        },
+                                        isModal: true,
+                                      ),
+                                      RegisterBtn(
+                                        btnName: '취소',
                                         onPressed: () {
                                           Navigator.pop(context);
                                         },
@@ -508,6 +515,27 @@ class _TranDetailPageState extends State<TranDetailPage> {
                                   );
                                 },
                               );
+                              } else {
+                                showDialog(
+                                  context: context,
+                                  builder: (BuildContext context) {
+                                    return CustomAlertDialog(
+                                      title: const Text('알림'),
+                                      content: const Text('진행 중이거나 완료된 거래는 파기할 수 없습니다.'),
+                                      actions: [
+                                        RegisterBtn(
+                                          btnName: '확인',
+                                          onPressed: () {
+                                            Navigator.pop(context);
+                                          },
+                                          isModal: true,
+                                        ),
+                                      ],
+                                    );
+                                  },
+                                );
+                              }
+                              
                             },
                             isModal: false,
                           ),

--- a/lib/src/pages/tran_detail_page.dart
+++ b/lib/src/pages/tran_detail_page.dart
@@ -47,14 +47,15 @@ class _TranDetailPageState extends State<TranDetailPage> {
   Future<void> sendToken() async {
     int? dealID = widget.dealId;
     AuthTokenGet authToken = AuthTokenGet();
+    print(dealID);
     try {
       http.Response response =
           await authToken.authTokenCallBack('deal-details?dealId=$dealID');
-      print(jsonDecode(response.body));
 
       if (response.statusCode == 200) {
         Map<String, dynamic> responseData =
             jsonDecode(utf8.decode(response.bodyBytes));
+            print(responseData);
         setState(() {
           tranDetail = TranDetailModel.fromJson(responseData);
         });

--- a/lib/src/services/tran_detail_model.dart
+++ b/lib/src/services/tran_detail_model.dart
@@ -11,7 +11,7 @@ class TranDetailModel {
   int? price;
   String? itemName;
   String? condition;
-  bool? depositStatus;
+  String? depositStatus;
   String? lockerPassword;
   String? createLockerPwdAt;
   String? dealStatus;


### PR DESCRIPTION
**lib/src/services/tran_detail_model.dart**
- depositStatus의 타입을 bool에서 String으로 변경

**lib/src/pages/tran_detail_page.dart**
- 거래 파기 시 거래 전일 때만 가능하도록 수정
- 메인 페이지에서 거래 목록 카드 클릭 하면 dealId를 넘겨 서버로 요청하도록 코드 작성