### PR TITLE
[Feature/#64] 간이계약서 작성 및 거래 대상자들의 서명 받기

### DIFF
--- a/lib/src/pages/register_tran_page.dart
+++ b/lib/src/pages/register_tran_page.dart
@@ -74,18 +74,20 @@ class _AppState extends State<RegisterTranPage> {
 
   Future<int> submit(BuildContext context) async {
     try {
+      int price = int.parse(itemPriceController.text);
       int dealId = await _registerPost.registerPost(
         bank: accountBankController!,
         account: accountController.text,
-        price: int.parse(itemPriceController.text),
+        price: price,
         itemName: itemNameController.text,
         condition: itemConditionController.text,
-        dealerId: dealerId.toString(),
+        dealerId: dealerId,
         lockerId: lockerIDController.text,
         isSeller: isSeller ?? false,
       );
       return dealId;
     } catch (e) {
+      print('error message $e');
       return -1;
     }
   }
@@ -348,6 +350,7 @@ class _AppState extends State<RegisterTranPage> {
                                   btnName: '확인',
                                   onPressed: () async {
                                     dealId = await submit(context);
+                                    print('거래를 등록할 때의 딜 아이디 $dealId');
                                     if (!mounted) return;
                                     if (int.parse(itemPriceController.text) >=
                                         50000) {
@@ -367,6 +370,8 @@ class _AppState extends State<RegisterTranPage> {
                                                       MaterialPageRoute(
                                                         builder: (context) =>
                                                             WriteContractPage(
+                                                          userInfo:
+                                                              widget.userInfo,
                                                           dealId: dealId,
                                                         ),
                                                       ),

--- a/lib/src/pages/register_tran_page.dart
+++ b/lib/src/pages/register_tran_page.dart
@@ -87,8 +87,7 @@ class _AppState extends State<RegisterTranPage> {
       );
       return dealId;
     } catch (e) {
-      print('error message $e');
-      return -1;
+      throw Exception(e);
     }
   }
 

--- a/lib/src/pages/register_tran_page.dart
+++ b/lib/src/pages/register_tran_page.dart
@@ -74,7 +74,6 @@ class _AppState extends State<RegisterTranPage> {
 
   Future<int> submit(BuildContext context) async {
     try {
-      print('try 들어왔다.');
       int dealId = await _registerPost.registerPost(
         bank: accountBankController!,
         account: accountController.text,
@@ -85,10 +84,8 @@ class _AppState extends State<RegisterTranPage> {
         lockerId: lockerIDController.text,
         isSeller: isSeller ?? false,
       );
-      print('register post완성했다.');
       return dealId;
     } catch (e) {
-      print("error message : $e");
       return -1;
     }
   }
@@ -162,7 +159,7 @@ class _AppState extends State<RegisterTranPage> {
                 hintText: '거래를 진행할 락커의 ID를 입력하세요.',
                 isDefault: true,
                 controller: lockerIDController,
-                ),
+              ),
               TextInput(
                 textType: '락커 주소',
                 hintText: '거래를 진행할 락커의 주소를 입력하세요.',
@@ -351,7 +348,6 @@ class _AppState extends State<RegisterTranPage> {
                                   btnName: '확인',
                                   onPressed: () async {
                                     dealId = await submit(context);
-                                    print("dealId : $dealId");
                                     if (!mounted) return;
                                     if (int.parse(itemPriceController.text) >=
                                         50000) {

--- a/lib/src/pages/tran_detail_page.dart
+++ b/lib/src/pages/tran_detail_page.dart
@@ -42,7 +42,6 @@ class _TranDetailPageState extends State<TranDetailPage> {
 
   late Map<String, dynamic> responseData;
   TranDetailModel tranDetail = TranDetailModel.fromJson({});
-  ContractDetailModel contractDetail = ContractDetailModel.fromJson({});
 
   Future<void> sendToken() async {
     int? dealID = widget.dealId;
@@ -82,20 +81,17 @@ class _TranDetailPageState extends State<TranDetailPage> {
     AuthTokenGet authToken = AuthTokenGet();
     try {
       http.Response response = await authToken
-          .authTokenCallBack('/contract/details?contractId=$contractID');
+          .authTokenCallBack('contract/details?contractId=$contractID');
+
+      print(response.statusCode);
 
       if (response.statusCode == 200) {
-        Map<String, dynamic> responseData =
-            jsonDecode(utf8.decode(response.bodyBytes));
-        setState(() {
-          contractDetail = ContractDetailModel.fromJson(responseData);
-        });
         if (!mounted) return;
         Navigator.push(
           context,
           MaterialPageRoute(
             builder: (context) => ViewContractPage(
-              contractDetailInfo: contractDetail,
+              tranDetail: tranDetail,
             ),
           ),
         );

--- a/lib/src/pages/tran_detail_page.dart
+++ b/lib/src/pages/tran_detail_page.dart
@@ -178,7 +178,6 @@ class _TranDetailPageState extends State<TranDetailPage> {
           .authTokenCallBack('deal-details/buyer-deal-complete?dealId=$dealID');
 
       if (response.statusCode == 200) {
-        print(response.body);
         setState(
           () {
             tranDetail.dealStatus = "COMPlETE";

--- a/lib/src/pages/tran_detail_page.dart
+++ b/lib/src/pages/tran_detail_page.dart
@@ -57,7 +57,6 @@ class _TranDetailPageState extends State<TranDetailPage> {
         setState(() {
           tranDetail = TranDetailModel.fromJson(responseData);
         });
-        print(tranDetail.sellerPhone == widget.userInfo.user?.phone);
         setState(() {
           if (tranDetail.sellerPhone == widget.userInfo.user?.phone) {
             if (tranDetail.depositStatus == "SELLER_DEPOSIT_CHECK") {

--- a/lib/src/pages/tran_detail_page.dart
+++ b/lib/src/pages/tran_detail_page.dart
@@ -54,6 +54,7 @@ class _TranDetailPageState extends State<TranDetailPage> {
       if (response.statusCode == 200) {
         Map<String, dynamic> responseData =
             jsonDecode(utf8.decode(response.bodyBytes));
+        print('이것은 tranDetail $responseData');
         setState(() {
           tranDetail = TranDetailModel.fromJson(responseData);
         });

--- a/lib/src/pages/view_contract_page.dart
+++ b/lib/src/pages/view_contract_page.dart
@@ -1,4 +1,10 @@
 import 'package:flutter/material.dart';
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import 'package:ojakgyo/src/services/auth_token_get.dart';
+import 'package:ojakgyo/src/services/contract_detail_model.dart';
+import 'package:ojakgyo/src/services/tran_detail_model.dart';
 
 import 'package:ojakgyo/widgets/back_navbar.dart';
 import 'package:ojakgyo/widgets/main_title.dart';
@@ -6,21 +12,46 @@ import 'package:ojakgyo/widgets/sub_title.dart';
 import 'package:ojakgyo/widgets/line.dart';
 import 'package:ojakgyo/widgets/register_btn.dart';
 
-import 'package:ojakgyo/src/services/contract_detail_model.dart';
-
 class ViewContractPage extends StatefulWidget {
   const ViewContractPage({
     Key? key,
-    required this.contractDetailInfo,
+    required this.tranDetail,
   }) : super(key: key);
 
-  final ContractDetailModel contractDetailInfo;
+  final TranDetailModel tranDetail;
 
   @override
   State<ViewContractPage> createState() => _ViewContractPageState();
 }
 
 class _ViewContractPageState extends State<ViewContractPage> {
+  ContractDetailModel contractDetail = ContractDetailModel();
+
+  Future<void> sendToken() async {
+    AuthTokenGet authToken = AuthTokenGet();
+    try {
+      http.Response response = await authToken.authTokenCallBack(
+          'contract/details?contractId=${widget.tranDetail.contactId}');
+
+      if (response.statusCode == 200) {
+        Map<String, dynamic> responseData =
+            jsonDecode(utf8.decode(response.bodyBytes));
+        print(responseData);
+        setState(() {
+          contractDetail = ContractDetailModel.fromJson(responseData);
+        });
+      }
+    } catch (e) {
+      throw Exception(e);
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    sendToken();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -61,7 +92,7 @@ class _ViewContractPageState extends State<ViewContractPage> {
                 ],
               ),
               const SubTitle(subTitle: '거래 당사자의 정보'),
-              const Row(
+              Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
@@ -69,16 +100,16 @@ class _ViewContractPageState extends State<ViewContractPage> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          '판매자',
+                        const Text(
+                          '< 판매자 >',
                           style: TextStyle(
-                            fontWeight: FontWeight.w500,
+                            fontWeight: FontWeight.w600,
                           ),
                         ),
-                        Text('성명 : 김철수'),
-                        Text('연락처 : 010-1234-5678'),
-                        Text('은행 : 농협'),
-                        Text('계좌번호 : 32114341434143'),
+                        Text('성명 : ${widget.tranDetail.sellerName}'),
+                        Text('연락처 : ${widget.tranDetail.sellerPhone}'),
+                        Text('은행 : ${widget.tranDetail.bank}'),
+                        Text('계좌번호 : ${widget.tranDetail.account}'),
                       ],
                     ),
                   ),
@@ -86,14 +117,14 @@ class _ViewContractPageState extends State<ViewContractPage> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          '구매자',
+                        const Text(
+                          '< 구매자 >',
                           style: TextStyle(
-                            fontWeight: FontWeight.w500,
+                            fontWeight: FontWeight.w600,
                           ),
                         ),
-                        Text('성명 : 박영희'),
-                        Text('연락처 : 010-9876-5432'),
+                        Text('성명 : ${widget.tranDetail.buyerName}'),
+                        Text('연락처 : ${widget.tranDetail.buyerPhone}'),
                       ],
                     ),
                   ),
@@ -103,15 +134,15 @@ class _ViewContractPageState extends State<ViewContractPage> {
                 height: 10,
               ),
               const SubTitle(subTitle: '거래 물품의 정보'),
-              const Text('물품명 : Apple airpod Pro 2세대 2023년형'),
-              const Text('상태 : 중고 (사용 기간 6개월, 상태 양호)'),
-              const Text('거래 금액: 1,200,000원'),
+              Text('물품명 : ${widget.tranDetail.itemName}'),
+              Text('상태 : ${widget.tranDetail.condition}'),
+              Text('거래 금액: ${widget.tranDetail.price}원'),
               const SizedBox(
                 height: 10,
               ),
               const SubTitle(subTitle: '거래 조건'),
-              const Text('(1) 거래 일시: 범위(사물함에 보관할 수 있는 범위)'),
-              const Text('(2) 거래 장소: 사물함 위치'),
+              Text('(1) 거래 일시: ${widget.tranDetail.createAtDeal}'),
+              Text('(2) 거래 장소: ${widget.tranDetail.lockerAddress}'),
               const Text('(3) 결제 방법: 계좌이체'),
               const SizedBox(
                 height: 10,
@@ -123,14 +154,12 @@ class _ViewContractPageState extends State<ViewContractPage> {
                 height: 10,
               ),
               const SubTitle(subTitle: '배상 및 책임 등'),
-              const Text(
-                  '(1) 판매자는 물품을 인도하기 전, 물품의 하자나 손상 여부를 확인하여야 합니다.\n(2) 구매자는 물품 수령 후, 물품에 대한 하자나 손상 여부를 확인하여야 합니다.\n(3) 물품의 소유권이 구매자에게 이전되기 전까지 발생하는 모든 손실, 손해, 멸실 또는 파손 등의 책임은 판매자가 부담합니다.\n(4) 물품의 소유권이 구매자에게 이전된 후 발생하는 모든 손실, 손해, 멸실 또는 파손 등의 책임은 구매자가 부담합니다.'),
+              Text('${contractDetail.repAndRes}'),
               const SizedBox(
                 height: 10,
               ),
               const SubTitle(subTitle: '기타 사항'),
-              const Text(
-                  '(1) 이 계약서에 명시되지 않은 사항에 대해서는 상호 합의하여 정합니다.\n(2) 이 계약서는 양 당사자가 본 계약서 내용을 충분히 이해하고 서명함으로써 효력이 발생합니다.\n(3) 이 계약서는 전자 문서로서도 유효하며, 이 경우에는 양 당사자가 전자 서명함으로써 효력이 발생합니다.\n(4) 본 계약서는 복사본으로도 효력이 있습니다.'),
+              Text('${contractDetail.note}'),
               const SizedBox(
                 height: 10,
               ),
@@ -141,30 +170,30 @@ class _ViewContractPageState extends State<ViewContractPage> {
                 height: 10,
               ),
               const SubTitle(subTitle: '판매자'),
-              const Row(
+              Row(
                 children: [
-                  Text('김철수'),
-                  SizedBox(
+                  Text('${widget.tranDetail.sellerName}'),
+                  const SizedBox(
                     width: 10,
                   ),
-                  Text('(인)'),
+                  const Text('(인)'),
                 ],
               ),
-              const Text('일자 : 2023년 8월 17일'),
+              Text('일자 : ${contractDetail.sellerSignatureCreatAt ?? ' '}'),
               const SizedBox(
                 height: 10,
               ),
               const SubTitle(subTitle: '구매자'),
-              const Row(
+              Row(
                 children: [
-                  Text('박영희'),
-                  SizedBox(
+                  Text('${widget.tranDetail.buyerName}'),
+                  const SizedBox(
                     width: 10,
                   ),
-                  Text('(인)'),
+                  const Text('(인)'),
                 ],
               ),
-              const Text('일자 : 2023년 8월 17일'),
+              Text('일자 : ${contractDetail.buyerSignatureCreatAt ?? ' '}'),
               const SizedBox(
                 height: 26,
               ),

--- a/lib/src/pages/write_contract_page.dart
+++ b/lib/src/pages/write_contract_page.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:ojakgyo/src/services/auth_token_get.dart';
+import 'package:ojakgyo/src/services/tran_detail_model.dart';
 import 'package:ojakgyo/widgets/back_navbar.dart';
 import 'package:ojakgyo/widgets/custom_alert_dialog.dart';
 import 'package:ojakgyo/widgets/line.dart';
@@ -7,6 +9,9 @@ import 'package:ojakgyo/widgets/register_btn.dart';
 import 'package:ojakgyo/widgets/signpad.dart';
 import 'package:ojakgyo/widgets/sub_title.dart';
 import 'package:ojakgyo/widgets/modify_contract.dart';
+
+import 'dart:convert';
+import 'package:http/http.dart' as http;
 
 class WriteContractPage extends StatefulWidget {
   const WriteContractPage({
@@ -28,6 +33,32 @@ class _WriteContractPageState extends State<WriteContractPage> {
       text:
           '(1) 이 계약서에 명시되지 않은 사항에 대해서는 상호 합의하여 정합니다.\n(2) 이 계약서는 양 당사자가 본 계약서 내용을 충분히 이해하고 서명함으로써 효력이 발생합니다.\n(3) 이 계약서는 전자 문서로서도 유효하며, 이 경우에는 양 당사자가 전자 서명함으로써 효력이 발생합니다.\n(4) 본 계약서는 복사본으로도 효력이 있습니다.');
 
+  TranDetailModel tranDetail = TranDetailModel();
+
+  Future<void> sendToken() async {
+    AuthTokenGet authToken = AuthTokenGet();
+    try {
+      http.Response response = await authToken
+          .authTokenCallBack('deal-details?dealId=${widget.dealId}');
+
+      if (response.statusCode == 200) {
+        Map<String, dynamic> responseData =
+            jsonDecode(utf8.decode(response.bodyBytes));
+        setState(() {
+          tranDetail = TranDetailModel.fromJson(responseData);
+        });
+      }
+    } catch (e) {
+      throw Exception(e);
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    sendToken();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -42,7 +73,7 @@ class _WriteContractPageState extends State<WriteContractPage> {
               const MainTitle(mainTitle: '간이계약서 작성'),
               const Line(),
               const SubTitle(subTitle: '거래 당사자의 정보'),
-              const Row(
+              Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
@@ -50,16 +81,16 @@ class _WriteContractPageState extends State<WriteContractPage> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          '판매자',
+                        const Text(
+                          '<판매자>',
                           style: TextStyle(
-                            fontWeight: FontWeight.w500,
+                            fontWeight: FontWeight.w600,
                           ),
                         ),
-                        Text('성명 : 김철수'),
-                        Text('연락처 : 010-1234-5678'),
-                        Text('은행 : 농협'),
-                        Text('계좌번호 : 32114341434143'),
+                        Text('성명 : ${tranDetail.sellerName}'),
+                        Text('연락처 : ${tranDetail.sellerPhone}'),
+                        Text('은행 : ${tranDetail.bank}'),
+                        Text('계좌번호 : ${tranDetail.account}'),
                       ],
                     ),
                   ),
@@ -67,14 +98,14 @@ class _WriteContractPageState extends State<WriteContractPage> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          '구매자',
+                        const Text(
+                          '<구매자>',
                           style: TextStyle(
-                            fontWeight: FontWeight.w500,
+                            fontWeight: FontWeight.w600,
                           ),
                         ),
-                        Text('성명 : 박영희'),
-                        Text('연락처 : 010-9876-5432'),
+                        Text('성명 : ${tranDetail.buyerName}'),
+                        Text('연락처 : ${tranDetail.buyerPhone}'),
                       ],
                     ),
                   ),
@@ -84,15 +115,15 @@ class _WriteContractPageState extends State<WriteContractPage> {
                 height: 10,
               ),
               const SubTitle(subTitle: '거래 물품의 정보'),
-              const Text('물품명 : Apple airpod Pro 2세대 2023년형'),
-              const Text('상태 : 중고 (사용 기간 6개월, 상태 양호)'),
-              const Text('거래 금액: 1,200,000원'),
+              Text('물품명 : ${tranDetail.itemName}'),
+              Text('상태 : ${tranDetail.condition}'),
+              Text('거래 금액: ${tranDetail.price}원'),
               const SizedBox(
                 height: 10,
               ),
               const SubTitle(subTitle: '거래 조건'),
               const Text('(1) 거래 일시: 범위(사물함에 보관할 수 있는 범위)'),
-              const Text('(2) 거래 장소: 사물함 위치'),
+              Text('(2) 거래 장소: ${tranDetail.lockerAddress}'),
               const Text('(3) 결제 방법: 계좌이체'),
               const SizedBox(
                 height: 10,

--- a/lib/src/pages/write_contract_page.dart
+++ b/lib/src/pages/write_contract_page.dart
@@ -108,9 +108,6 @@ class _WriteContractPageState extends State<WriteContractPage> {
                       children: [
                         const Text(
                           '< 판매자 >',
-                          style: TextStyle(
-                            fontWeight: FontWeight.w600,
-                          ),
                         ),
                         Text('성명 : ${tranDetail.sellerName}'),
                         Text('연락처 : ${tranDetail.sellerPhone}'),
@@ -125,9 +122,6 @@ class _WriteContractPageState extends State<WriteContractPage> {
                       children: [
                         const Text(
                           '< 구매자 >',
-                          style: TextStyle(
-                            fontWeight: FontWeight.w600,
-                          ),
                         ),
                         Text('성명 : ${tranDetail.buyerName}'),
                         Text('연락처 : ${tranDetail.buyerPhone}'),

--- a/lib/src/pages/write_contract_page.dart
+++ b/lib/src/pages/write_contract_page.dart
@@ -94,7 +94,7 @@ class _WriteContractPageState extends State<WriteContractPage> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         const Text(
-                          '<판매자>',
+                          '< 판매자 >',
                           style: TextStyle(
                             fontWeight: FontWeight.w600,
                           ),
@@ -111,7 +111,7 @@ class _WriteContractPageState extends State<WriteContractPage> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         const Text(
-                          '<구매자>',
+                          '< 구매자 >',
                           style: TextStyle(
                             fontWeight: FontWeight.w600,
                           ),

--- a/lib/src/pages/write_contract_page.dart
+++ b/lib/src/pages/write_contract_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ojakgyo/src/services/auth_token_get.dart';
 import 'package:ojakgyo/src/services/tran_detail_model.dart';
+import 'package:ojakgyo/src/services/user_info_model.dart';
 import 'package:ojakgyo/widgets/back_navbar.dart';
 import 'package:ojakgyo/widgets/custom_alert_dialog.dart';
 import 'package:ojakgyo/widgets/line.dart';
@@ -16,9 +17,11 @@ import 'package:http/http.dart' as http;
 class WriteContractPage extends StatefulWidget {
   const WriteContractPage({
     Key? key,
+    required this.userInfo,
     required this.dealId,
   }) : super(key: key);
 
+  final UserInfoModel userInfo;
   final int dealId;
 
   @override
@@ -37,6 +40,7 @@ class _WriteContractPageState extends State<WriteContractPage> {
 
   Future<void> sendToken() async {
     AuthTokenGet authToken = AuthTokenGet();
+    print(widget.dealId);
     try {
       http.Response response = await authToken
           .authTokenCallBack('deal-details?dealId=${widget.dealId}');
@@ -46,17 +50,25 @@ class _WriteContractPageState extends State<WriteContractPage> {
             jsonDecode(utf8.decode(response.bodyBytes));
         setState(() {
           tranDetail = TranDetailModel.fromJson(responseData);
+          print('계약서 쓰기 $responseData');
         });
+      } else {
+        print('실패지롱 ${response.statusCode}');
       }
     } catch (e) {
       throw Exception(e);
     }
   }
 
+  bool isSeller() {
+    return tranDetail.sellerName == widget.userInfo.user?.name;
+  }
+
   @override
   void initState() {
     super.initState();
     sendToken();
+    print(tranDetail.buyerName);
   }
 
   @override
@@ -224,7 +236,10 @@ class _WriteContractPageState extends State<WriteContractPage> {
                                     showDialog(
                                       context: context,
                                       builder: (BuildContext context) {
-                                        return const SignPad();
+                                        return SignPad(
+                                          isSeller: isSeller(),
+                                          contractId: tranDetail.contactId!,
+                                        );
                                       },
                                     );
                                   },

--- a/lib/src/pages/write_contract_page.dart
+++ b/lib/src/pages/write_contract_page.dart
@@ -190,13 +190,13 @@ class _WriteContractPageState extends State<WriteContractPage> {
                 height: 10,
               ),
               const SubTitle(subTitle: '판매자'),
-              const Row(
+              Row(
                 children: [
-                  Text('김철수'),
-                  SizedBox(
+                  Text(tranDetail.sellerName ?? 'Unknown'),
+                  const SizedBox(
                     width: 10,
                   ),
-                  Text('(인)'),
+                  const Text('(인)'),
                 ],
               ),
               const Text('일자 : 2023년 8월 17일'),
@@ -204,13 +204,13 @@ class _WriteContractPageState extends State<WriteContractPage> {
                 height: 10,
               ),
               const SubTitle(subTitle: '구매자'),
-              const Row(
+              Row(
                 children: [
-                  Text('박영희'),
-                  SizedBox(
+                  Text(tranDetail.buyerName ?? 'Unknown'),
+                  const SizedBox(
                     width: 10,
                   ),
-                  Text('(인)'),
+                  const Text('(인)'),
                 ],
               ),
               const Text('일자 : 2023년 8월 17일'),

--- a/lib/src/services/contract_detail_model.dart
+++ b/lib/src/services/contract_detail_model.dart
@@ -3,15 +3,24 @@ class ContractDetailModel {
   String? note;
   String? sellerSignature;
   String? buyerSignature;
+  String? sellerSignatureCreatAt;
+  String? buyerSignatureCreatAt;
 
   ContractDetailModel(
-      {this.repAndRes, this.note, this.sellerSignature, this.buyerSignature});
+      {this.repAndRes,
+      this.note,
+      this.sellerSignature,
+      this.buyerSignature,
+      this.sellerSignatureCreatAt,
+      this.buyerSignatureCreatAt});
 
   ContractDetailModel.fromJson(Map<String, dynamic> json) {
     repAndRes = json['repAndRes'];
     note = json['note'];
     sellerSignature = json['sellerSignature'];
     buyerSignature = json['buyerSignature'];
+    sellerSignatureCreatAt = json['sellerSignatureCreatAt'];
+    buyerSignatureCreatAt = json['buyerSignatureCreatAt'];
   }
 
   Map<String, dynamic> toJson() {
@@ -20,6 +29,8 @@ class ContractDetailModel {
     data['note'] = note;
     data['sellerSignature'] = sellerSignature;
     data['buyerSignature'] = buyerSignature;
+    data['sellerSignatureCreatAt'] = sellerSignatureCreatAt;
+    data['buyerSignatureCreatAt'] = buyerSignatureCreatAt;
     return data;
   }
 }

--- a/lib/src/services/contract_post.dart
+++ b/lib/src/services/contract_post.dart
@@ -2,25 +2,26 @@ import 'package:http/http.dart' as http;
 import 'package:ojakgyo/src/services/auth_token_get.dart';
 import 'dart:convert';
 
-class SignaturePost {
+class ContractPost {
   final String baseURL =
       'http://ec2-15-164-170-1.ap-northeast-2.compute.amazonaws.com:8080';
 
-  Future<String> signaturePost({
-    required bool isSeller,
-    required String signature,
-    required int contractId,
+  Future<int> contractPost({
+    required int dealId,
+    required String repAndRes,
+    required String note,
+    required int price,
   }) async {
     String? authToken = AuthTokenManage.getToken();
 
     final Map<String, dynamic> requestData = {
-      'isSeller': isSeller,
-      'signature': signature,
-      'contractId': contractId,
+      'dealId': dealId,
+      'repAndRes': repAndRes,
+      'note': note,
+      'price': price,
     };
 
-    final request =
-        http.Request('POST', Uri.parse('$baseURL/contract/signature'));
+    final request = http.Request('POST', Uri.parse('$baseURL/contract'));
     request.headers['Authorization'] = authToken!;
     request.headers['Content-Type'] = 'application/json';
     request.body = json.encode(requestData);
@@ -29,11 +30,11 @@ class SignaturePost {
 
     if (response.statusCode == 200) {
       final responseBody = await response.stream.bytesToString();
-      String signAt = responseBody;
-
-      return signAt;
+      final responseData = json.decode(responseBody);
+      final int contractId = responseData;
+      return contractId;
     } else {
-      return 'Unknown';
+      return -999;
     }
   }
 }

--- a/lib/src/services/register_post.dart
+++ b/lib/src/services/register_post.dart
@@ -15,12 +15,8 @@ class RegisterPost {
     required String dealerId,
     required String lockerId,
     required bool isSeller,
-  }) 
-  async {
+  }) async {
     String? authToken = AuthTokenManage.getToken();
-    print(authToken);
-
-    print("이제 서버로 보낸다..");
 
     final Map<String, dynamic> requestData = {
       'bank': bank,
@@ -40,19 +36,12 @@ class RegisterPost {
 
     final response = await http.Client().send(request);
 
-
-    print("보냄");
-
     if (response.statusCode == 200) {
-      print("서버로 갔다");
-      final responseBody = await response.stream.bytesToString(); // 스트림 데이터를 문자열로 변환
-      final responseData = json.decode(responseBody); // JSON으로 파싱
+      final responseBody = await response.stream.bytesToString();
+      final responseData = json.decode(responseBody);
       final int dealId = responseData['dealId'];
-
-
       return dealId;
     } else {
-      print(response.statusCode);
       return -999;
     }
   }

--- a/lib/src/services/signature_post.dart
+++ b/lib/src/services/signature_post.dart
@@ -30,7 +30,7 @@ class SignaturePost {
     if (response.statusCode == 200) {
       final responseBody = await response.stream.bytesToString();
       final responseData = json.decode(responseBody);
-      final int contractId = responseData['contractId'];
+      print(responseData);
 
       return contractId;
     } else {

--- a/lib/src/services/signature_post.dart
+++ b/lib/src/services/signature_post.dart
@@ -30,7 +30,7 @@ class SignaturePost {
     if (response.statusCode == 200) {
       final responseBody = await response.stream.bytesToString();
       final responseData = json.decode(responseBody);
-      print(responseData);
+      print('response는 이렇습니다.. $responseData');
 
       return contractId;
     } else {

--- a/lib/src/services/signature_post.dart
+++ b/lib/src/services/signature_post.dart
@@ -2,34 +2,25 @@ import 'package:http/http.dart' as http;
 import 'package:ojakgyo/src/services/auth_token_get.dart';
 import 'dart:convert';
 
-class RegisterPost {
+class SignaturePost {
   final String baseURL =
       'http://ec2-15-164-170-1.ap-northeast-2.compute.amazonaws.com:8080';
 
-  Future<int> registerPost({
-    required String bank,
-    required String account,
-    required int price,
-    required String itemName,
-    required String condition,
-    required int dealerId,
-    required String lockerId,
+  Future<int> signaturePost({
     required bool isSeller,
+    required String signature,
+    required int contractId,
   }) async {
     String? authToken = AuthTokenManage.getToken();
 
     final Map<String, dynamic> requestData = {
-      'bank': bank,
-      'account': account,
-      'price': price,
-      'itemName': itemName,
-      'condition': condition,
-      'dealerId': dealerId,
-      'lockerId': lockerId,
       'isSeller': isSeller,
+      'signature': signature,
+      'contractId': contractId,
     };
 
-    final request = http.Request('POST', Uri.parse('$baseURL/deal'));
+    final request =
+        http.Request('POST', Uri.parse('$baseURL/contract/signature'));
     request.headers['Authorization'] = authToken!;
     request.headers['Content-Type'] = 'application/json';
     request.body = json.encode(requestData);
@@ -39,8 +30,9 @@ class RegisterPost {
     if (response.statusCode == 200) {
       final responseBody = await response.stream.bytesToString();
       final responseData = json.decode(responseBody);
-      final int dealId = responseData;
-      return dealId;
+      final int contractId = responseData['contractId'];
+
+      return contractId;
     } else {
       return -999;
     }

--- a/lib/src/services/tran_detail_model.dart
+++ b/lib/src/services/tran_detail_model.dart
@@ -14,6 +14,7 @@ class TranDetailModel {
   String? depositStatus;
   String? lockerPassword;
   String? createLockerPwdAt;
+  String? createAtDeal;
   String? dealStatus;
 
   TranDetailModel(
@@ -32,6 +33,7 @@ class TranDetailModel {
       depositStatus,
       lockerPassword,
       createLockerPwdAt,
+      createAtDeal,
       dealStatus});
 
   TranDetailModel.fromJson(Map<String, dynamic> json) {
@@ -50,6 +52,7 @@ class TranDetailModel {
     depositStatus = json['depositStatus'];
     lockerPassword = json['lockerPassword'];
     createLockerPwdAt = json['createLockerPwdAt'];
+    createAtDeal = json['createAtDeal'];
     dealStatus = json['dealStatus'];
   }
 
@@ -70,6 +73,7 @@ class TranDetailModel {
     data['depositStatus'] = depositStatus;
     data['lockerPassword'] = lockerPassword;
     data['createLockerPwdAt'] = createLockerPwdAt;
+    data['createAtDeal'] = createAtDeal;
     data['dealStatus'] = dealStatus;
     return data;
   }

--- a/lib/widgets/signpad.dart
+++ b/lib/widgets/signpad.dart
@@ -77,7 +77,7 @@ class _SignPadState extends State<SignPad> {
             ),
             SfSignaturePad(
               key: _signaturePadGlobalKey,
-              backgroundColor: const Color(0xFFD9D9D9),
+              backgroundColor: Colors.transparent,
               minimumStrokeWidth: 4.0,
               maximumStrokeWidth: 4.0,
             ),

--- a/lib/widgets/signpad.dart
+++ b/lib/widgets/signpad.dart
@@ -4,9 +4,17 @@ import 'package:ojakgyo/widgets/register_btn.dart';
 import 'dart:convert';
 import 'dart:ui' as ui;
 import 'package:ojakgyo/src/pages/main_page.dart';
+import 'package:ojakgyo/src/services/signature_post.dart';
 
 class SignPad extends StatefulWidget {
-  const SignPad({Key? key}) : super(key: key);
+  const SignPad({
+    Key? key,
+    required this.isSeller,
+    required this.contractId,
+  }) : super(key: key);
+
+  final bool isSeller;
+  final int contractId;
 
   @override
   State<SignPad> createState() => _SignPadState();
@@ -14,6 +22,27 @@ class SignPad extends StatefulWidget {
 
 class _SignPadState extends State<SignPad> {
   final GlobalKey<SfSignaturePadState> _signaturePadGlobalKey = GlobalKey();
+  final SignaturePost _signaturePost = SignaturePost();
+
+  Future<int> sendSign() async {
+    final signatureImage = await _signaturePadGlobalKey.currentState!.toImage();
+    final signatureBytes =
+        await signatureImage.toByteData(format: ui.ImageByteFormat.png);
+    final signatureBase64 = base64Encode(signatureBytes!.buffer.asUint8List());
+
+    print(signatureBase64);
+
+    try {
+      int contractId = await _signaturePost.signaturePost(
+          isSeller: widget.isSeller,
+          signature: signatureBase64,
+          contractId: widget.contractId);
+
+      return contractId;
+    } catch (e) {
+      throw Exception(e);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -68,13 +97,7 @@ class _SignPadState extends State<SignPad> {
         RegisterBtn(
           btnName: '확인',
           onPressed: () async {
-            // 이미지 파일로 받아서 Encode
-            // final signatureImage =
-            //     await _signaturePadGlobalKey.currentState!.toImage();
-            // final signatureBytes =
-            //     await signatureImage.toByteData(format: ui.ImageByteFormat.png);
-            // final signatureBase64 =
-            //     base64Encode(signatureBytes!.buffer.asUint8List());
+            sendSign();
 
             if (!mounted) return;
             Navigator.push(

--- a/lib/widgets/signpad.dart
+++ b/lib/widgets/signpad.dart
@@ -30,8 +30,6 @@ class _SignPadState extends State<SignPad> {
         await signatureImage.toByteData(format: ui.ImageByteFormat.png);
     final signatureBase64 = base64Encode(signatureBytes!.buffer.asUint8List());
 
-    print(signatureBase64);
-
     try {
       int contractId = await _signaturePost.signaturePost(
           isSeller: widget.isSeller,
@@ -106,9 +104,6 @@ class _SignPadState extends State<SignPad> {
                 builder: (context) => const MainPage(),
               ),
             );
-
-            // 서버에서 받아올 때 Decode 테스트
-            // final signatureBytes_result = base64Decode(signatureBase64);
           },
           isModal: true,
         ),

--- a/lib/widgets/signpad.dart
+++ b/lib/widgets/signpad.dart
@@ -24,19 +24,19 @@ class _SignPadState extends State<SignPad> {
   final GlobalKey<SfSignaturePadState> _signaturePadGlobalKey = GlobalKey();
   final SignaturePost _signaturePost = SignaturePost();
 
-  Future<int> sendSign() async {
+  Future<String> sendSign() async {
     final signatureImage = await _signaturePadGlobalKey.currentState!.toImage();
     final signatureBytes =
         await signatureImage.toByteData(format: ui.ImageByteFormat.png);
     final signatureBase64 = base64Encode(signatureBytes!.buffer.asUint8List());
 
     try {
-      int contractId = await _signaturePost.signaturePost(
+      String signAt = await _signaturePost.signaturePost(
           isSeller: widget.isSeller,
           signature: signatureBase64,
           contractId: widget.contractId);
 
-      return contractId;
+      return signAt;
     } catch (e) {
       throw Exception(e);
     }
@@ -95,7 +95,8 @@ class _SignPadState extends State<SignPad> {
         RegisterBtn(
           btnName: '확인',
           onPressed: () async {
-            sendSign();
+            String signAt = await sendSign();
+            print(signAt);
 
             if (!mounted) return;
             Navigator.push(


### PR DESCRIPTION
**lib/src/services/signature_post.dart**
- 서명을 서버로 post 하는 서비스

**lib/widgets/signpad.dart**
- 배경을 진회색 -> 투명색
- 서명 확정시 signaturePost를 호출

**lib/src/pages/write_contract_page.dart**
- 서명 날짜 및 거래 등록 날짜 적용

**lib/src/pages/view_contract_page.dart**
- 서명 날짜 및 거래 등록 날짜 적용
- 거래 대상자의 서명을 받아 (인)에 겹쳐 출력

issues : #62 #64 #85 